### PR TITLE
Merge Michael Schmitz Buildpack updates for ruby-gnome and friends

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -162,6 +162,12 @@ EOF
   echo -n "$pkg_config_path" > "$apt_env_dir/PKG_CONFIG_PATH.prepend"
   echo -n ":" > "$apt_env_dir/PKG_CONFIG_PATH.delim"
 
+  gi_typelib_path=$apt_layer/usr/lib/x86_64-linux-gnu/girepository-1.0:$apt_layer/usr/lib/i386-linux-gnu/girepository-1.0
+  echo "GI_TYPELIB_PATH=$gi_typelib_path" | indent
+  echo "GI_TYPELIB_PATH = \"$gi_typelib_path:\$GI_TYPELIB_PATH\"" >> "$exports_path"
+  echo -n "$gi_typelib_path" > "$apt_env_dir/GI_TYPELIB_PATH.prepend"
+  echo -n ":" > "$apt_env_dir/GI_TYPELIB_PATH.delim"
+
   echo 'EOF' >> "$exports_path"
   echo '' >> "$exports_path"
 fi


### PR DESCRIPTION
[See Michael's commit](https://github.com/michaelschmitz/heroku-buildpack-apt/commit/5918ae9c8749ae738ebd4771678f525d65bedf39)

This was necessary to remove a:
```
GObjectIntrospection::RepositoryError::TypelibNotFound: Typelib file for namespace 'Poppler' (any version) not found
build     /layers/heroku_ruby/gems/ruby/3.1.0/gems/gobject-introspection-4.1.8/lib/gobject-introspection/loader.rb:40:in 'require'
```